### PR TITLE
Add Docker setup and docs-as-code

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+eda/
+node_modules/
+.env
+.git/
+.gitignore
+__pycache__/
+*.pyc
+.cache*
+diagrama.png
+docs/
+CLAUDE.md
+README.MD

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+CLIENT_ID=
+CLIENT_SECRET=
+SPOTIFY_USERNAME=
+SCOPE=user-read-private user-top-read user-library-read
+REDIRECT_URI=http://localhost:5000/login
+DB_NAME=spotify_organizer
+URI_DB=mongodb://mongo:27017/spotify_organizer

--- a/.env.example
+++ b/.env.example
@@ -4,4 +4,6 @@ SPOTIFY_USERNAME=
 SCOPE=user-read-private user-top-read user-library-read
 REDIRECT_URI=http://localhost:5000/login
 DB_NAME=spotify_organizer
-URI_DB=mongodb://mongo:27017/spotify_organizer
+# Para desarrollo sin Docker: mongodb://localhost:27017/spotify_organizer
+# Con Docker Compose: se sobreescribe automáticamente a mongodb://mongo:27017/spotify_organizer
+URI_DB=mongodb://localhost:27017/spotify_organizer

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ env/
 __pycache__/
 *__pycache__
 *.pyc
+node_modules/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,50 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+A Spanish-language Flask web app that organizes Spotify liked songs into playlists using K-means clustering and cosine similarity-based recommendations. Users authenticate via Spotify OAuth, browse/search tracks, and get personalized recommendations based on audio features.
+
+## Commands
+
+```bash
+# Install Python dependencies
+pip install -r requirements.txt
+
+# Install Tailwind (for CSS)
+npm install
+
+# Run the dev server
+python index.py
+
+# Build Tailwind CSS (watches templates in app/templates/ and app/static/js/)
+npx tailwindcss -o app/static/css/output.css --watch
+```
+
+## Required Environment Variables
+
+Set in `.env` (loaded via python-dotenv): `CLIENT_ID`, `CLIENT_SECRET`, `SPOTIFY_USERNAME`, `SCOPE`, `REDIRECT_URI`, `DB_NAME`, `URI_DB`.
+
+## Architecture
+
+**Entry point:** `index.py` calls `create_app()` from `app/app.py`, which initializes the Flask app, connects to MongoDB, and registers three blueprints.
+
+**Blueprints (route modules):**
+- `app/auth/` — Spotify OAuth login/logout, session management. Controller in `controlador.py`.
+- `app/public/` — Homepage, search, song player, recommendation endpoint (`/recomendar`).
+- `app/user/` — Favorites, listening history (requires auth via `before_request`).
+
+**Key layers:**
+- `app/spotify/spotify.py` — `SpotifyApi` class wrapping `spotipy`. Stored as `app.config["spotify_client"]` (single shared instance). Uses `@renew_token_if_needed` decorator for automatic token refresh on 401s.
+- `app/algoritmo/recomendacion.py` — Recommendation engine using cosine similarity on audio features (Danceability, Energy, Speechiness, etc.) from `app/algoritmo/datasets/Spotify.csv`. Module-level globals (`df_musica`, `matriz_similaridad`) are computed at import time. Also has `filtro_colaborativo()` for user-based collaborative filtering.
+- `app/db/` — MongoDB via MongoEngine. Models: `Usuario`, `Favoritos`, `Historial`, `Playlist`.
+- `app/decorators/decorators.py` — `@no_login_required` redirects authenticated users away from login pages.
+
+**Frontend:** Jinja2 templates in `app/templates/`, styled with Tailwind CSS. Static JS in `app/static/js/`.
+
+**EDA:** `eda/` contains exploratory data analysis scripts (separate from the main app).
+
+## Language
+
+The codebase (variable names, comments, docstrings) is primarily in Spanish.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,15 @@
-FROM python:3.11-slim
+FROM python:3.11.12-slim
+
+RUN useradd -m app
 
 WORKDIR /app
 
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY . .
+COPY --chown=app:app . .
+
+USER app
 
 EXPOSE 5000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 5000
+
+CMD ["gunicorn", "-b", "0.0.0.0:5000", "index:app"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+services:
+  app:
+    build: .
+    ports:
+      - "5000:5000"
+    env_file:
+      - .env
+    depends_on:
+      - mongo
+      - redis
+    volumes:
+      - .:/app
+    command: gunicorn -b 0.0.0.0:5000 --reload index:app
+
+  mongo:
+    image: mongo:7
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo_data:/data/db
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+
+volumes:
+  mongo_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,13 @@ services:
       - "5000:5000"
     env_file:
       - .env
+    environment:
+      - URI_DB=mongodb://mongo:27017/spotify_organizer
     depends_on:
-      - mongo
-      - redis
+      mongo:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     volumes:
       - .:/app
     command: gunicorn -b 0.0.0.0:5000 --reload index:app
@@ -18,11 +22,21 @@ services:
       - "27017:27017"
     volumes:
       - mongo_data:/data/db
+    healthcheck:
+      test: mongosh --eval "db.runCommand('ping').ok" --quiet
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
   redis:
     image: redis:7-alpine
     ports:
       - "6379:6379"
+    healthcheck:
+      test: redis-cli ping
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
 volumes:
   mongo_data:

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,30 @@
+# Docs as Code
+
+Documentacion tecnica del proyecto, versionada junto al codigo.
+
+## Estructura
+
+```
+docs/
+  plans/       # Planes de implementacion y roadmaps
+  adrs/        # Architecture Decision Records
+```
+
+## Convenciones
+
+### Plans
+
+Documentan que se va a hacer y por que. Formato:
+
+- `PLAN-NNN-titulo.md`
+- Incluyen: contexto, fases, orden de ejecucion
+- Estados: `propuesto`, `en-progreso`, `completado`, `descartado`
+
+### ADRs
+
+Registran decisiones arquitectonicas importantes. Formato:
+
+- `ADR-NNN-titulo.md`
+- Basado en [Michael Nygard's template](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions)
+- Estados: `propuesto`, `aceptado`, `deprecado`, `reemplazado`
+- Un ADR nunca se borra, solo se marca como deprecado/reemplazado con referencia al nuevo

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,12 +1,12 @@
 # Docs as Code
 
-Documentacion tecnica del proyecto, versionada junto al codigo.
+Documentación técnica del proyecto, versionada junto al código.
 
 ## Estructura
 
 ```
 docs/
-  plans/       # Planes de implementacion y roadmaps
+  plans/       # Planes de implementación y roadmaps
   adrs/        # Architecture Decision Records
 ```
 
@@ -14,17 +14,17 @@ docs/
 
 ### Plans
 
-Documentan que se va a hacer y por que. Formato:
+Documentan qué se va a hacer y por qué. Formato:
 
-- `PLAN-NNN-titulo.md`
-- Incluyen: contexto, fases, orden de ejecucion
+- `PLAN-NNN-título.md`
+- Incluyen: contexto, fases, orden de ejecución
 - Estados: `propuesto`, `en-progreso`, `completado`, `descartado`
 
 ### ADRs
 
-Registran decisiones arquitectonicas importantes. Formato:
+Registran decisiones arquitectónicas importantes. Formato:
 
-- `ADR-NNN-titulo.md`
+- `ADR-NNN-título.md`
 - Basado en [Michael Nygard's template](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions)
 - Estados: `propuesto`, `aceptado`, `deprecado`, `reemplazado`
 - Un ADR nunca se borra, solo se marca como deprecado/reemplazado con referencia al nuevo

--- a/docs/adrs/ADR-000-template.md
+++ b/docs/adrs/ADR-000-template.md
@@ -1,0 +1,27 @@
+# ADR-NNN: Titulo de la decision
+
+- **Estado**: propuesto | aceptado | deprecado | reemplazado por [ADR-NNN](ADR-NNN-titulo.md)
+- **Fecha**: YYYY-MM-DD
+- **Autor**: Nombre
+
+## Contexto
+
+Que situacion o problema motiva esta decision? Que restricciones existen?
+
+## Decision
+
+Que se decidio hacer?
+
+## Alternativas consideradas
+
+### Alternativa A
+- Pros
+- Contras
+
+### Alternativa B
+- Pros
+- Contras
+
+## Consecuencias
+
+Que implica esta decision? Que trade-offs se aceptan?

--- a/docs/adrs/ADR-000-template.md
+++ b/docs/adrs/ADR-000-template.md
@@ -1,16 +1,16 @@
-# ADR-NNN: Titulo de la decision
+# ADR-NNN: Título de la decisión
 
-- **Estado**: propuesto | aceptado | deprecado | reemplazado por [ADR-NNN](ADR-NNN-titulo.md)
+- **Estado**: propuesto | aceptado | deprecado | reemplazado por [ADR-NNN](ADR-NNN-título.md)
 - **Fecha**: YYYY-MM-DD
 - **Autor**: Nombre
 
 ## Contexto
 
-Que situacion o problema motiva esta decision? Que restricciones existen?
+¿Qué situación o problema motiva esta decisión? ¿Qué restricciones existen?
 
-## Decision
+## Decisión
 
-Que se decidio hacer?
+¿Qué se decidió hacer?
 
 ## Alternativas consideradas
 
@@ -24,4 +24,4 @@ Que se decidio hacer?
 
 ## Consecuencias
 
-Que implica esta decision? Que trade-offs se aceptan?
+¿Qué implica esta decisión? ¿Qué trade-offs se aceptan?

--- a/docs/adrs/ADR-001-flask-con-mongodb-y-spotipy.md
+++ b/docs/adrs/ADR-001-flask-con-mongodb-y-spotipy.md
@@ -6,29 +6,29 @@
 
 ## Contexto
 
-Se necesitaba una app web que interactue con la API de Spotify para organizar canciones en playlists usando algoritmos de ML. El proyecto es personal/academico, con un solo desarrollador.
+Se necesitaba una app web que interactúe con la API de Spotify para organizar canciones en playlists usando algoritmos de ML. El proyecto es personal/académico, con un solo desarrollador.
 
-## Decision
+## Decisión
 
 - **Backend**: Flask con blueprints (auth, public, user)
-- **Base de datos**: MongoDB via MongoEngine (modelos: Usuario, Favoritos, Historial, Playlist)
-- **Spotify API**: Spotipy como wrapper, con autenticacion OAuth2
+- **Base de datos**: MongoDB vía MongoEngine (modelos: Usuario, Favoritos, Historial, Playlist)
+- **Spotify API**: Spotipy como wrapper, con autenticación OAuth2
 - **Frontend**: Jinja2 templates + Tailwind CSS
 - **ML**: scikit-learn (K-means, cosine similarity) + pandas
 
 ## Alternativas consideradas
 
 ### Django + PostgreSQL
-- Pros: ORM mas maduro, admin panel gratis
-- Contras: Overhead para un proyecto con schema flexible (audio features varian), mas opinionado
+- Pros: ORM más maduro, admin panel gratis
+- Contras: Overhead para un proyecto con schema flexible (audio features varían), más opinionado
 
 ### FastAPI + MongoDB
-- Pros: Async nativo, documentacion automatica de API
-- Contras: Al momento del inicio del proyecto, Flask era mas familiar y el frontend es server-rendered (Jinja2), no SPA
+- Pros: Async nativo, documentación automática de API
+- Contras: Al momento del inicio del proyecto, Flask era más familiar y el frontend es server-rendered (Jinja2), no SPA
 
 ## Consecuencias
 
 - MongoDB es bueno para documentos flexibles (audio features, metadata de canciones) pero no tiene relaciones fuertes
 - MongoEngine da estructura con modelos tipo ORM
-- Flask es ligero pero requiere mas setup manual (blueprints, sesiones, error handling)
-- Spotipy simplifica la interaccion con Spotify pero tiene limitaciones en manejo de tokens multi-usuario
+- Flask es ligero pero requiere más setup manual (blueprints, sesiones, error handling)
+- Spotipy simplifica la interacción con Spotify pero tiene limitaciones en manejo de tokens multi-usuario

--- a/docs/adrs/ADR-001-flask-con-mongodb-y-spotipy.md
+++ b/docs/adrs/ADR-001-flask-con-mongodb-y-spotipy.md
@@ -1,0 +1,34 @@
+# ADR-001: Flask con MongoDB y Spotipy como stack base
+
+- **Estado**: aceptado
+- **Fecha**: 2026-04-09
+- **Autor**: Rody Vilchez
+
+## Contexto
+
+Se necesitaba una app web que interactue con la API de Spotify para organizar canciones en playlists usando algoritmos de ML. El proyecto es personal/academico, con un solo desarrollador.
+
+## Decision
+
+- **Backend**: Flask con blueprints (auth, public, user)
+- **Base de datos**: MongoDB via MongoEngine (modelos: Usuario, Favoritos, Historial, Playlist)
+- **Spotify API**: Spotipy como wrapper, con autenticacion OAuth2
+- **Frontend**: Jinja2 templates + Tailwind CSS
+- **ML**: scikit-learn (K-means, cosine similarity) + pandas
+
+## Alternativas consideradas
+
+### Django + PostgreSQL
+- Pros: ORM mas maduro, admin panel gratis
+- Contras: Overhead para un proyecto con schema flexible (audio features varian), mas opinionado
+
+### FastAPI + MongoDB
+- Pros: Async nativo, documentacion automatica de API
+- Contras: Al momento del inicio del proyecto, Flask era mas familiar y el frontend es server-rendered (Jinja2), no SPA
+
+## Consecuencias
+
+- MongoDB es bueno para documentos flexibles (audio features, metadata de canciones) pero no tiene relaciones fuertes
+- MongoEngine da estructura con modelos tipo ORM
+- Flask es ligero pero requiere mas setup manual (blueprints, sesiones, error handling)
+- Spotipy simplifica la interaccion con Spotify pero tiene limitaciones en manejo de tokens multi-usuario

--- a/docs/adrs/ADR-002-cosine-similarity-para-recomendaciones.md
+++ b/docs/adrs/ADR-002-cosine-similarity-para-recomendaciones.md
@@ -1,0 +1,29 @@
+# ADR-002: Cosine similarity sobre audio features para recomendaciones
+
+- **Estado**: aceptado
+- **Fecha**: 2026-04-09
+- **Autor**: Rody Vilchez
+
+## Contexto
+
+La app necesita recomendar canciones similares a una dada. Se dispone de audio features de Spotify (danceability, energy, speechiness, acousticness, instrumentalness, valence, tempo) tanto en un dataset generico de 18K tracks como en las liked songs del usuario.
+
+## Decision
+
+Usar cosine similarity sobre 7 audio features numericas para encontrar canciones similares. Implementado en `app/algoritmo/recomendacion.py` con una matriz de similitud precalculada al iniciar la app.
+
+## Alternativas consideradas
+
+### Euclidean distance
+- Pros: Intuitivo, simple
+- Contras: Sensible a la escala de las features (tempo en BPM vs danceability 0-1). Requiere normalizacion obligatoria
+
+### Modelo de embeddings (neural)
+- Pros: Captura relaciones no lineales
+- Contras: Requiere datos de entrenamiento masivos, overhead de infraestructura, no justificado para el volumen actual
+
+## Consecuencias
+
+- La matriz se calcula en import time sobre todo el CSV — funciona pero escala mal con datasets grandes
+- Cosine similarity es invariante a la magnitud, lo que ayuda con features de distinta escala
+- Las recomendaciones dependen de un CSV estatico generico, no de las canciones reales del usuario (ver PLAN-001 Fase 3.1 para mejora planificada)

--- a/docs/adrs/ADR-002-cosine-similarity-para-recomendaciones.md
+++ b/docs/adrs/ADR-002-cosine-similarity-para-recomendaciones.md
@@ -6,17 +6,17 @@
 
 ## Contexto
 
-La app necesita recomendar canciones similares a una dada. Se dispone de audio features de Spotify (danceability, energy, speechiness, acousticness, instrumentalness, valence, tempo) tanto en un dataset generico de 18K tracks como en las liked songs del usuario.
+La app necesita recomendar canciones similares a una dada. Se dispone de audio features de Spotify (danceability, energy, speechiness, acousticness, instrumentalness, valence, tempo) tanto en un dataset genérico de 18K tracks como en las liked songs del usuario.
 
-## Decision
+## Decisión
 
-Usar cosine similarity sobre 7 audio features numericas para encontrar canciones similares. Implementado en `app/algoritmo/recomendacion.py` con una matriz de similitud precalculada al iniciar la app.
+Usar cosine similarity sobre 7 audio features numéricas para encontrar canciones similares. Implementado en `app/algoritmo/recomendacion.py` con una matriz de similitud precalculada al iniciar la app.
 
 ## Alternativas consideradas
 
 ### Euclidean distance
 - Pros: Intuitivo, simple
-- Contras: Sensible a la escala de las features (tempo en BPM vs danceability 0-1). Requiere normalizacion obligatoria
+- Contras: Sensible a la escala de las features (tempo en BPM vs danceability 0-1). Requiere normalización obligatoria
 
 ### Modelo de embeddings (neural)
 - Pros: Captura relaciones no lineales
@@ -26,4 +26,4 @@ Usar cosine similarity sobre 7 audio features numericas para encontrar canciones
 
 - La matriz se calcula en import time sobre todo el CSV — funciona pero escala mal con datasets grandes
 - Cosine similarity es invariante a la magnitud, lo que ayuda con features de distinta escala
-- Las recomendaciones dependen de un CSV estatico generico, no de las canciones reales del usuario (ver PLAN-001 Fase 3.1 para mejora planificada)
+- Las recomendaciones dependen de un CSV estático genérico, no de las canciones reales del usuario (ver PLAN-001 Fase 3.1 para mejora planificada)

--- a/docs/adrs/ADR-003-kmeans-para-clustering-de-playlists.md
+++ b/docs/adrs/ADR-003-kmeans-para-clustering-de-playlists.md
@@ -1,0 +1,33 @@
+# ADR-003: K-means para clustering de liked songs en playlists
+
+- **Estado**: aceptado
+- **Fecha**: 2026-04-09
+- **Autor**: Rody Vilchez
+
+## Contexto
+
+El objetivo principal del proyecto es agrupar las liked songs del usuario en playlists tematicas automaticamente. El EDA en `eda/clasificador.ipynb` exploro este problema con 571 canciones y sus audio features + generos.
+
+## Decision
+
+Usar K-means con el siguiente pipeline:
+1. Audio features normalizadas con StandardScaler
+2. Generos vectorizados con TF-IDF
+3. Reduccion de dimensionalidad con PCA (37 componentes, 75% varianza)
+4. K-means con k=5, inicializacion k-means++, algoritmo Elkan
+
+## Alternativas consideradas
+
+### DBSCAN / HDBSCAN
+- Pros: No requiere definir k, detecta clusters de forma arbitraria, maneja outliers
+- Contras: Mas sensible a parametros (epsilon, min_samples), menos predecible en numero de playlists resultantes
+
+### Solo audio features (sin generos)
+- Pros: Menos dimensiones, menos ruido
+- Contras: Pierde informacion semantica que agrupa artistas del mismo genero
+
+## Consecuencias
+
+- El EDA mostro desbalance severo: cluster 3 contiene 89.8% de las canciones (513/571). Esto sugiere que el pipeline con generos TF-IDF domina el clustering por proximidad semantica de nacionalidades/generos, no por audio features
+- **Accion pendiente**: Experimentar con solo audio features o ajustar el peso relativo de generos vs features antes de integrar en la app (ver PLAN-001 Fase 2.2)
+- K-means asume clusters esfericos — puede no capturar bien grupos con formas irregulares en el espacio de audio features

--- a/docs/adrs/ADR-003-kmeans-para-clustering-de-playlists.md
+++ b/docs/adrs/ADR-003-kmeans-para-clustering-de-playlists.md
@@ -6,28 +6,28 @@
 
 ## Contexto
 
-El objetivo principal del proyecto es agrupar las liked songs del usuario en playlists tematicas automaticamente. El EDA en `eda/clasificador.ipynb` exploro este problema con 571 canciones y sus audio features + generos.
+El objetivo principal del proyecto es agrupar las liked songs del usuario en playlists temáticas automáticamente. El EDA en `eda/clasificador.ipynb` exploró este problema con 571 canciones y sus audio features + géneros.
 
-## Decision
+## Decisión
 
 Usar K-means con el siguiente pipeline:
 1. Audio features normalizadas con StandardScaler
-2. Generos vectorizados con TF-IDF
-3. Reduccion de dimensionalidad con PCA (37 componentes, 75% varianza)
-4. K-means con k=5, inicializacion k-means++, algoritmo Elkan
+2. Géneros vectorizados con TF-IDF
+3. Reducción de dimensionalidad con PCA (37 componentes, 75% varianza)
+4. K-means con k=5, inicialización k-means++, algoritmo Elkan
 
 ## Alternativas consideradas
 
 ### DBSCAN / HDBSCAN
 - Pros: No requiere definir k, detecta clusters de forma arbitraria, maneja outliers
-- Contras: Mas sensible a parametros (epsilon, min_samples), menos predecible en numero de playlists resultantes
+- Contras: Más sensible a parámetros (epsilon, min_samples), menos predecible en número de playlists resultantes
 
-### Solo audio features (sin generos)
+### Solo audio features (sin géneros)
 - Pros: Menos dimensiones, menos ruido
-- Contras: Pierde informacion semantica que agrupa artistas del mismo genero
+- Contras: Pierde información semántica que agrupa artistas del mismo género
 
 ## Consecuencias
 
-- El EDA mostro desbalance severo: cluster 3 contiene 89.8% de las canciones (513/571). Esto sugiere que el pipeline con generos TF-IDF domina el clustering por proximidad semantica de nacionalidades/generos, no por audio features
-- **Accion pendiente**: Experimentar con solo audio features o ajustar el peso relativo de generos vs features antes de integrar en la app (ver PLAN-001 Fase 2.2)
-- K-means asume clusters esfericos — puede no capturar bien grupos con formas irregulares en el espacio de audio features
+- El EDA mostró desbalance severo: cluster 3 contiene 89.8% de las canciones (513/571). Esto sugiere que el pipeline con géneros TF-IDF domina el clustering por proximidad semántica de nacionalidades/géneros, no por audio features
+- **Acción pendiente**: Experimentar con solo audio features o ajustar el peso relativo de géneros vs features antes de integrar en la app (ver PLAN-001 Fase 2.2)
+- K-means asume clusters esféricos — puede no capturar bien grupos con formas irregulares en el espacio de audio features

--- a/docs/adrs/ADR-004-render-atlas-para-deploy.md
+++ b/docs/adrs/ADR-004-render-atlas-para-deploy.md
@@ -1,0 +1,37 @@
+# ADR-004: Render + MongoDB Atlas para deploy gratuito
+
+- **Estado**: propuesto
+- **Fecha**: 2026-04-09
+- **Autor**: Rody Vilchez
+
+## Contexto
+
+Se necesita un deploy gratuito para portafolio/demo. La app usa Flask + MongoDB. Requisitos: $0/mes, URL publica, soporte para Python + MongoDB, deploy desde GitHub.
+
+## Decision
+
+- **App**: Render free tier (web service con Docker)
+- **BD**: MongoDB Atlas free tier (M0, 512MB)
+- **Cache**: Upstash Redis free tier (10K comandos/dia)
+- **Server**: gunicorn en vez del dev server de Flask
+
+## Alternativas consideradas
+
+### Railway
+- Pros: UX excelente, deploy rapido, MongoDB addon integrado
+- Contras: Elimino el free tier en 2023. Requiere plan de $5/mes minimo
+
+### Fly.io
+- Pros: Edge computing, buen free tier para apps
+- Contras: No tiene MongoDB managed — requiere correr Mongo en un volumen (fragil) o usar Atlas igual. Mas complejo de configurar
+
+### Vercel
+- Pros: Deploy instantaneo, excelente para frontend
+- Contras: Serverless — Flask no es ideal. Cold starts largos con scikit-learn en memoria
+
+## Consecuencias
+
+- Render free duerme la app tras 15min de inactividad — primer request tarda ~30s en despertar. Aceptable para demo
+- Atlas M0 tiene 512MB — suficiente para historial/favoritos de pocos usuarios
+- gunicorn reemplaza al dev server de Flask para produccion
+- Deploy automatico desde main via GitHub — cualquier push actualiza la app

--- a/docs/adrs/ADR-004-render-atlas-para-deploy.md
+++ b/docs/adrs/ADR-004-render-atlas-para-deploy.md
@@ -6,32 +6,32 @@
 
 ## Contexto
 
-Se necesita un deploy gratuito para portafolio/demo. La app usa Flask + MongoDB. Requisitos: $0/mes, URL publica, soporte para Python + MongoDB, deploy desde GitHub.
+Se necesita un deploy gratuito para portafolio/demo. La app usa Flask + MongoDB. Requisitos: $0/mes, URL pública, soporte para Python + MongoDB, deploy desde GitHub.
 
-## Decision
+## Decisión
 
 - **App**: Render free tier (web service con Docker)
 - **BD**: MongoDB Atlas free tier (M0, 512MB)
-- **Cache**: Upstash Redis free tier (10K comandos/dia)
+- **Cache**: Upstash Redis free tier (10K comandos/día)
 - **Server**: gunicorn en vez del dev server de Flask
 
 ## Alternativas consideradas
 
 ### Railway
-- Pros: UX excelente, deploy rapido, MongoDB addon integrado
-- Contras: Elimino el free tier en 2023. Requiere plan de $5/mes minimo
+- Pros: UX excelente, deploy rápido, MongoDB addon integrado
+- Contras: Eliminó el free tier en 2023. Requiere plan de $5/mes mínimo
 
 ### Fly.io
 - Pros: Edge computing, buen free tier para apps
-- Contras: No tiene MongoDB managed — requiere correr Mongo en un volumen (fragil) o usar Atlas igual. Mas complejo de configurar
+- Contras: No tiene MongoDB managed — requiere correr Mongo en un volumen (frágil) o usar Atlas igual. Más complejo de configurar
 
 ### Vercel
-- Pros: Deploy instantaneo, excelente para frontend
+- Pros: Deploy instantáneo, excelente para frontend
 - Contras: Serverless — Flask no es ideal. Cold starts largos con scikit-learn en memoria
 
 ## Consecuencias
 
 - Render free duerme la app tras 15min de inactividad — primer request tarda ~30s en despertar. Aceptable para demo
 - Atlas M0 tiene 512MB — suficiente para historial/favoritos de pocos usuarios
-- gunicorn reemplaza al dev server de Flask para produccion
-- Deploy automatico desde main via GitHub — cualquier push actualiza la app
+- gunicorn reemplaza al dev server de Flask para producción
+- Deploy automático desde main vía GitHub — cualquier push actualiza la app

--- a/docs/plans/PLAN-001-roadmap-integracion-kmeans.md
+++ b/docs/plans/PLAN-001-roadmap-integracion-kmeans.md
@@ -1,4 +1,4 @@
-# PLAN-001: Roadmap - Integracion del clustering y mejoras generales
+# PLAN-001: Roadmap - Integración del clustering y mejoras generales
 
 - **Estado**: propuesto
 - **Fecha**: 2026-04-09
@@ -6,20 +6,20 @@
 
 ## Contexto
 
-La app Flask tiene autenticacion Spotify, busqueda, reproductor, recomendaciones por cosine similarity, y historial/favoritos en MongoDB. En paralelo, el directorio `eda/` tiene trabajo maduro: extraccion de liked songs con audio features, clustering K-means (5 clusters con TF-IDF de generos + audio features), y creacion de playlists en Spotify. Sin embargo, nada del EDA esta integrado en la app web. El dataset de recomendaciones (`app/algoritmo/datasets/Spotify.csv`, 18K tracks) es estatico y generico, no usa los datos reales del usuario.
+La app Flask tiene autenticación Spotify, búsqueda, reproductor, recomendaciones por cosine similarity, y historial/favoritos en MongoDB. En paralelo, el directorio `eda/` tiene trabajo maduro: extracción de liked songs con audio features, clustering K-means (5 clusters con TF-IDF de géneros + audio features), y creación de playlists en Spotify. Sin embargo, nada del EDA está integrado en la app web. El dataset de recomendaciones (`app/algoritmo/datasets/Spotify.csv`, 18K tracks) es estático y genérico, no usa los datos reales del usuario.
 
 ---
 
-## Fase 1: Fundamentos (bugs criticos)
+## Fase 1: Fundamentos (bugs críticos)
 
 ### 1.1 — SpotifyApi multi-usuario
 - **Problema**: Hay una sola instancia de `SpotifyApi` en `app.config["spotify_client"]`. Si dos usuarios se logean, el token del segundo sobreescribe al primero.
-- **Solucion**: Mover token/refresh_token a la sesion o a MongoDB (`Usuario`). Que cada request use el token de la sesion para crear/inicializar el cliente Spotify.
+- **Solución**: Mover token/refresh_token a la sesión o a MongoDB (`Usuario`). Que cada request use el token de la sesión para crear/inicializar el cliente Spotify.
 - **Archivos**: `app/app.py`, `app/spotify/spotify.py`, `app/auth/routes.py`, `app/public/routes.py`, `app/user/routes.py`
 
-### 1.2 — Manejo de errores basico
+### 1.2 — Manejo de errores básico
 - Reemplazar `print()` por `logging`
-- Las rutas que hacen `except: return {"status": False}` ocultan bugs. Al menos loggear la excepcion.
+- Las rutas que hacen `except: return {"status": False}` ocultan bugs. Al menos loggear la excepción.
 - **Archivos**: `app/user/routes.py`, `app/spotify/spotify.py`
 
 ---
@@ -29,17 +29,17 @@ La app Flask tiene autenticacion Spotify, busqueda, reproductor, recomendaciones
 ### 2.1 — Extraer audio features del usuario en tiempo real
 - Usar `spotify_client.audio_features()` de spotipy para obtener las features de las liked songs del usuario (como hace `eda/get_spotify_list.ipynb`).
 - Cachear en MongoDB o Redis para no repetir llamadas.
-- **Referencia**: `eda/get_spotify_list.ipynb` ya tiene la logica de extraccion batch + cache de generos en `artist_genre_cache.json`.
+- **Referencia**: `eda/get_spotify_list.ipynb` ya tiene la lógica de extracción batch + cache de géneros en `artist_genre_cache.json`.
 
-### 2.2 — Modulo de clustering
-- Extraer la logica de `eda/clasificador.ipynb` a un modulo Python reutilizable (ej: `app/algoritmo/clustering.py`).
-- Pipeline: normalizacion -> TF-IDF de generos -> PCA -> K-means.
-- Permitir al usuario elegir numero de clusters o usar el elbow method automatico.
-- **Nota**: El EDA mostro desbalance fuerte (cluster 3 = 89.8% de canciones). Considerar ajustar: usar solo audio features sin generos, o probar DBSCAN/HDBSCAN como alternativa.
+### 2.2 — Módulo de clustering
+- Extraer la lógica de `eda/clasificador.ipynb` a un módulo Python reutilizable (ej: `app/algoritmo/clustering.py`).
+- Pipeline: normalización -> TF-IDF de géneros -> PCA -> K-means.
+- Permitir al usuario elegir número de clusters o usar el elbow method automático.
+- **Nota**: El EDA mostró desbalance fuerte (cluster 3 = 89.8% de canciones). Considerar ajustar: usar solo audio features sin géneros, o probar DBSCAN/HDBSCAN como alternativa.
 
 ### 2.3 — Crear playlists en Spotify desde la app
-- Endpoint nuevo: `/crear-playlists` que ejecute el clustering y cree las playlists via API.
-- Reusar logica de `eda/crear_playlist.ipynb` (batch add de 100 tracks).
+- Endpoint nuevo: `/crear-playlists` que ejecute el clustering y cree las playlists vía API.
+- Reusar lógica de `eda/crear_playlist.ipynb` (batch add de 100 tracks).
 - El modelo `Playlist` en `app/db/models/playlist.py` ya existe pero no se usa — conectarlo.
 
 ---
@@ -47,8 +47,8 @@ La app Flask tiene autenticacion Spotify, busqueda, reproductor, recomendaciones
 ## Fase 3: Mejorar recomendaciones
 
 ### 3.1 — Recomendaciones basadas en datos del usuario
-- Reemplazar el CSV estatico de 18K tracks por las audio features reales de las canciones del usuario.
-- `recomendacion.py` ya tiene `get_best_recommendations()` y `filtro_colaborativo()` — adaptar para que trabajen con datos dinamicos en vez de globals de modulo.
+- Reemplazar el CSV estático de 18K tracks por las audio features reales de las canciones del usuario.
+- `recomendacion.py` ya tiene `get_best_recommendations()` y `filtro_colaborativo()` — adaptar para que trabajen con datos dinámicos en vez de globals de módulo.
 - **Archivos**: `app/algoritmo/recomendacion.py`
 
 ### 3.2 — Filtro colaborativo funcional
@@ -61,11 +61,11 @@ La app Flask tiene autenticacion Spotify, busqueda, reproductor, recomendaciones
 ## Fase 4: Frontend y UX
 
 ### 4.1 — Vista de clusters
-- Pagina donde el usuario vea sus canciones agrupadas por cluster con nombres descriptivos (basados en las caracteristicas dominantes del cluster).
-- Boton "Crear playlist en Spotify" por cada cluster.
+- Página donde el usuario vea sus canciones agrupadas por cluster con nombres descriptivos (basados en las características dominantes del cluster).
+- Botón "Crear playlist en Spotify" por cada cluster.
 
-### 4.2 — Visualizacion
-- Integrar la visualizacion 3D de PCA (como `eda/file5k.html` con Plotly) en la app para que el usuario vea sus clusters interactivamente.
+### 4.2 — Visualización
+- Integrar la visualización 3D de PCA (como `eda/file5k.html` con Plotly) en la app para que el usuario vea sus clusters interactivamente.
 
 ---
 
@@ -83,12 +83,12 @@ La app Flask tiene autenticacion Spotify, busqueda, reproductor, recomendaciones
 
 ---
 
-## Orden sugerido de ejecucion
+## Orden sugerido de ejecución
 
 ```
 Fase 1.1 (multi-usuario) -> Fase 2.1 (audio features) -> Fase 2.2 (clustering module)
--> Fase 2.3 (crear playlists) -> Fase 3.1 (recomendaciones dinamicas)
+-> Fase 2.3 (crear playlists) -> Fase 3.1 (recomendaciones dinámicas)
 -> Fase 4.1 (vista clusters) -> Fase 5 (tests, docker, deploy)
 ```
 
-Las fases 1.2, 3.2, 4.2 y 5.x se pueden intercalar segun prioridad.
+Las fases 1.2, 3.2, 4.2 y 5.x se pueden intercalar según prioridad.

--- a/docs/plans/PLAN-001-roadmap-integracion-kmeans.md
+++ b/docs/plans/PLAN-001-roadmap-integracion-kmeans.md
@@ -1,0 +1,94 @@
+# PLAN-001: Roadmap - Integracion del clustering y mejoras generales
+
+- **Estado**: propuesto
+- **Fecha**: 2026-04-09
+- **Autor**: Rody Vilchez
+
+## Contexto
+
+La app Flask tiene autenticacion Spotify, busqueda, reproductor, recomendaciones por cosine similarity, y historial/favoritos en MongoDB. En paralelo, el directorio `eda/` tiene trabajo maduro: extraccion de liked songs con audio features, clustering K-means (5 clusters con TF-IDF de generos + audio features), y creacion de playlists en Spotify. Sin embargo, nada del EDA esta integrado en la app web. El dataset de recomendaciones (`app/algoritmo/datasets/Spotify.csv`, 18K tracks) es estatico y generico, no usa los datos reales del usuario.
+
+---
+
+## Fase 1: Fundamentos (bugs criticos)
+
+### 1.1 — SpotifyApi multi-usuario
+- **Problema**: Hay una sola instancia de `SpotifyApi` en `app.config["spotify_client"]`. Si dos usuarios se logean, el token del segundo sobreescribe al primero.
+- **Solucion**: Mover token/refresh_token a la sesion o a MongoDB (`Usuario`). Que cada request use el token de la sesion para crear/inicializar el cliente Spotify.
+- **Archivos**: `app/app.py`, `app/spotify/spotify.py`, `app/auth/routes.py`, `app/public/routes.py`, `app/user/routes.py`
+
+### 1.2 — Manejo de errores basico
+- Reemplazar `print()` por `logging`
+- Las rutas que hacen `except: return {"status": False}` ocultan bugs. Al menos loggear la excepcion.
+- **Archivos**: `app/user/routes.py`, `app/spotify/spotify.py`
+
+---
+
+## Fase 2: Integrar el K-means del EDA en la app
+
+### 2.1 — Extraer audio features del usuario en tiempo real
+- Usar `spotify_client.audio_features()` de spotipy para obtener las features de las liked songs del usuario (como hace `eda/get_spotify_list.ipynb`).
+- Cachear en MongoDB o Redis para no repetir llamadas.
+- **Referencia**: `eda/get_spotify_list.ipynb` ya tiene la logica de extraccion batch + cache de generos en `artist_genre_cache.json`.
+
+### 2.2 — Modulo de clustering
+- Extraer la logica de `eda/clasificador.ipynb` a un modulo Python reutilizable (ej: `app/algoritmo/clustering.py`).
+- Pipeline: normalizacion -> TF-IDF de generos -> PCA -> K-means.
+- Permitir al usuario elegir numero de clusters o usar el elbow method automatico.
+- **Nota**: El EDA mostro desbalance fuerte (cluster 3 = 89.8% de canciones). Considerar ajustar: usar solo audio features sin generos, o probar DBSCAN/HDBSCAN como alternativa.
+
+### 2.3 — Crear playlists en Spotify desde la app
+- Endpoint nuevo: `/crear-playlists` que ejecute el clustering y cree las playlists via API.
+- Reusar logica de `eda/crear_playlist.ipynb` (batch add de 100 tracks).
+- El modelo `Playlist` en `app/db/models/playlist.py` ya existe pero no se usa — conectarlo.
+
+---
+
+## Fase 3: Mejorar recomendaciones
+
+### 3.1 — Recomendaciones basadas en datos del usuario
+- Reemplazar el CSV estatico de 18K tracks por las audio features reales de las canciones del usuario.
+- `recomendacion.py` ya tiene `get_best_recommendations()` y `filtro_colaborativo()` — adaptar para que trabajen con datos dinamicos en vez de globals de modulo.
+- **Archivos**: `app/algoritmo/recomendacion.py`
+
+### 3.2 — Filtro colaborativo funcional
+- `filtro_colaborativo()` existe pero no se llama desde ninguna ruta.
+- Necesita un DataFrame de usuarios x canciones que se construya desde MongoDB (`Historial`, `Favoritos`).
+- Agregar endpoint `/recomendaciones-colaborativas`.
+
+---
+
+## Fase 4: Frontend y UX
+
+### 4.1 — Vista de clusters
+- Pagina donde el usuario vea sus canciones agrupadas por cluster con nombres descriptivos (basados en las caracteristicas dominantes del cluster).
+- Boton "Crear playlist en Spotify" por cada cluster.
+
+### 4.2 — Visualizacion
+- Integrar la visualizacion 3D de PCA (como `eda/file5k.html` con Plotly) en la app para que el usuario vea sus clusters interactivamente.
+
+---
+
+## Fase 5: Infraestructura
+
+### 5.1 — Tests
+- Unit tests para `recomendacion.py` (funciones puras: `clean_data`, `get_similarities`, `filtro_colaborativo`).
+- Integration tests para las rutas principales.
+
+### 5.2 — Docker
+- `docker-compose.yml` con Flask + MongoDB + Redis.
+
+### 5.3 — Deploy
+- Railway/Render/Fly.io con Spotify API en modo development.
+
+---
+
+## Orden sugerido de ejecucion
+
+```
+Fase 1.1 (multi-usuario) -> Fase 2.1 (audio features) -> Fase 2.2 (clustering module)
+-> Fase 2.3 (crear playlists) -> Fase 3.1 (recomendaciones dinamicas)
+-> Fase 4.1 (vista clusters) -> Fase 5 (tests, docker, deploy)
+```
+
+Las fases 1.2, 3.2, 4.2 y 5.x se pueden intercalar segun prioridad.

--- a/docs/plans/PLAN-002-deploy-y-wow.md
+++ b/docs/plans/PLAN-002-deploy-y-wow.md
@@ -4,7 +4,7 @@
 - **Fecha**: 2026-04-09
 - **Autor**: Rody Vilchez
 
-**Objetivo**: Portafolio/demo con link vivo, costo $0, maximo impacto visual y funcional.
+**Objetivo**: Portafolio/demo con link vivo, costo $0, máximo impacto visual y funcional.
 
 ---
 
@@ -12,11 +12,11 @@
 
 ### Infraestructura
 
-| Servicio | Proveedor | Tier | Limites |
+| Servicio | Proveedor | Tier | Límites |
 |----------|-----------|------|---------|
 | App Flask | Render (web service) | Free | Sleep tras 15min inactividad, 750h/mes |
 | MongoDB | MongoDB Atlas | Free (M0) | 512MB, cluster compartido |
-| Redis (cache) | Upstash | Free | 10K comandos/dia, 256MB |
+| Redis (cache) | Upstash | Free | 10K comandos/día, 256MB |
 
 ### Archivos a crear
 
@@ -35,7 +35,7 @@
 2. Crear cuenta Render, conectar repo GitHub
 3. Configurar env vars en Render
 4. Configurar Redirect URI en Spotify Dashboard
-5. Deploy automatico desde main
+5. Deploy automático desde main
 
 ---
 
@@ -45,17 +45,17 @@
 
 **UI estilo Spotify** — Dark theme (#1DB954 verde, #191414 fondo), cards con cover art, animaciones hover, transiciones CSS.
 
-**Mood Ring** — Resumen visual tipo Spotify Wrapped con audio features promedio del usuario. "Tu musica es 73% bailable". Gauges animados. Datos ya disponibles.
+**Mood Ring** — Resumen visual tipo Spotify Wrapped con audio features promedio del usuario. "Tu música es 73% bailable". Gauges animados. Datos ya disponibles.
 
-**One-click playlist creation** — Boton "Crear en Spotify" por cluster. Logica ya existe en `eda/crear_playlist.ipynb`.
+**One-click playlist creation** — Botón "Crear en Spotify" por cluster. Lógica ya existe en `eda/crear_playlist.ipynb`.
 
 ### Impacto alto + esfuerzo medio
 
-**Visualizacion 3D de clusters** — Plotly.js scatter 3D, cada punto una cancion coloreada por cluster. Hover muestra nombre + artista, click abre en Spotify. PCA 3 componentes. Ya explorado en `eda/file5k.html`.
+**Visualización 3D de clusters** — Plotly.js scatter 3D, cada punto una canción coloreada por cluster. Hover muestra nombre + artista, click abre en Spotify. PCA 3 componentes. Ya explorado en `eda/file5k.html`.
 
 **Radar chart por cluster** — Chart.js/Plotly mostrando perfil de audio features (danceability, energy, valence, etc). Comparar clusters lado a lado.
 
-**Nombres de playlists con LLM** — Claude Haiku o reglas basicas. Input: artistas + features promedio + generos. Output: nombre creativo + emoji + descripcion.
+**Nombres de playlists con LLM** — Claude Haiku o reglas básicas. Input: artistas + features promedio + géneros. Output: nombre creativo + emoji + descripción.
 
 ### Impacto medio + esfuerzo medio
 
@@ -63,9 +63,9 @@
 
 ---
 
-## Verificacion
+## Verificación
 
 1. `docker-compose up` levanta app + mongo localmente
 2. Login con Spotify funciona con redirect a localhost
-3. Deploy en Render: URL publica responde, login redirige correctamente
+3. Deploy en Render: URL pública responde, login redirige correctamente
 4. MongoDB Atlas conecta desde Render

--- a/docs/plans/PLAN-002-deploy-y-wow.md
+++ b/docs/plans/PLAN-002-deploy-y-wow.md
@@ -1,0 +1,71 @@
+# PLAN-002: Despliegue gratuito + features efecto wow
+
+- **Estado**: propuesto
+- **Fecha**: 2026-04-09
+- **Autor**: Rody Vilchez
+
+**Objetivo**: Portafolio/demo con link vivo, costo $0, maximo impacto visual y funcional.
+
+---
+
+## Parte 1: Despliegue
+
+### Infraestructura
+
+| Servicio | Proveedor | Tier | Limites |
+|----------|-----------|------|---------|
+| App Flask | Render (web service) | Free | Sleep tras 15min inactividad, 750h/mes |
+| MongoDB | MongoDB Atlas | Free (M0) | 512MB, cluster compartido |
+| Redis (cache) | Upstash | Free | 10K comandos/dia, 256MB |
+
+### Archivos a crear
+
+1. `Dockerfile` — Python 3.11-slim, gunicorn como server
+2. `docker-compose.yml` — flask + mongo + redis para desarrollo local
+3. `.dockerignore` — excluir eda/, node_modules/, .env, __pycache__
+4. `render.yaml` — Infrastructure as Code para Render
+5. Agregar `gunicorn` a `requirements.txt`
+
+### Spotify API
+- Agregar URL de Render a Redirect URIs en Spotify Developer Dashboard
+- Development Mode: hasta 25 usuarios (suficiente para demo)
+
+### Pasos
+1. Crear cluster MongoDB Atlas free (M0)
+2. Crear cuenta Render, conectar repo GitHub
+3. Configurar env vars en Render
+4. Configurar Redirect URI en Spotify Dashboard
+5. Deploy automatico desde main
+
+---
+
+## Parte 2: Features efecto wow
+
+### Impacto alto + esfuerzo bajo
+
+**UI estilo Spotify** — Dark theme (#1DB954 verde, #191414 fondo), cards con cover art, animaciones hover, transiciones CSS.
+
+**Mood Ring** — Resumen visual tipo Spotify Wrapped con audio features promedio del usuario. "Tu musica es 73% bailable". Gauges animados. Datos ya disponibles.
+
+**One-click playlist creation** — Boton "Crear en Spotify" por cluster. Logica ya existe en `eda/crear_playlist.ipynb`.
+
+### Impacto alto + esfuerzo medio
+
+**Visualizacion 3D de clusters** — Plotly.js scatter 3D, cada punto una cancion coloreada por cluster. Hover muestra nombre + artista, click abre en Spotify. PCA 3 componentes. Ya explorado en `eda/file5k.html`.
+
+**Radar chart por cluster** — Chart.js/Plotly mostrando perfil de audio features (danceability, energy, valence, etc). Comparar clusters lado a lado.
+
+**Nombres de playlists con LLM** — Claude Haiku o reglas basicas. Input: artistas + features promedio + generos. Output: nombre creativo + emoji + descripcion.
+
+### Impacto medio + esfuerzo medio
+
+**Compatibilidad entre amigos** — Cosine similarity de perfiles de audio features entre usuarios. Compartible en redes.
+
+---
+
+## Verificacion
+
+1. `docker-compose up` levanta app + mongo localmente
+2. Login con Spotify funciona con redirect a localhost
+3. Deploy en Render: URL publica responde, login redirige correctamente
+4. MongoDB Atlas conecta desde Render

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,6 +33,7 @@ tzdata==2024.1
 urllib3==2.6.3
 yellowbrick
 Werkzeug==3.0.1
+gunicorn==22.0.0
 
 
 


### PR DESCRIPTION
## Summary
- Dockerfile + docker-compose for local dev (Flask with hot-reload, MongoDB 7, Redis 7)
- `.env.example` template with all required env vars
- `gunicorn` added to requirements for production server
- CLAUDE.md for Claude Code context
- Docs-as-code structure: plans (roadmap, deploy) and ADRs (stack, recommendations, clustering, infra)

## How to use
```bash
cp .env.example .env
# Fill in Spotify credentials
docker compose up
# App at localhost:5000
```

## Test plan
- [ ] `docker compose build` completes without errors
- [ ] `docker compose up` starts all 3 services (app, mongo, redis)
- [ ] App responds at `localhost:5000`
- [ ] Hot-reload works (edit a template, see changes without restart)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add containerized local development setup and introduce a structured docs-as-code system for architecture and planning.

New Features:
- Provide Dockerfile and docker-compose configuration to run the Flask app with MongoDB and Redis in containers.
- Add example environment file for configuring required application environment variables.

Enhancements:
- Add gunicorn as the production WSGI server dependency for the Flask application.
- Document project architecture, decisions, and implementation roadmap using plans and ADRs under a new docs/ directory.
- Introduce CLAUDE.md to describe the project and development workflow for AI-assisted coding tools.

Documentation:
- Create docs-as-code structure with plans and Architecture Decision Records documenting stack choices, recommendation approach, and deployment strategy.