### PR TITLE
Fix multi-user: token per session instead of global

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -2,22 +2,24 @@ from flask import Flask
 from secrets import token_hex
 from os import getenv
 
-from .spotify import SpotifyApi
+from .spotify import SpotifyAuth
 from .db import create_conetion_db
 
 from dotenv import load_dotenv
 
 load_dotenv()
 
-def create_conn_spotify() -> SpotifyApi:
-    return SpotifyApi(getenv("CLIENT_ID"), getenv("CLIENT_SECRET"), getenv("SPOTIFY_USERNAME"), getenv("SCOPE"), getenv("REDIRECT_URI"))
-
 
 def create_app() -> Flask:
     app = Flask(__name__)
     app.config['SECRET_KEY'] = token_hex(16)
-    app.config["spotify_client"] = create_conn_spotify()
-    
+    app.config["spotify_auth"] = SpotifyAuth(
+        getenv("CLIENT_ID"),
+        getenv("CLIENT_SECRET"),
+        getenv("SCOPE"),
+        getenv("REDIRECT_URI"),
+    )
+
     create_conetion_db()
 
     from .auth import auth_routes
@@ -27,5 +29,5 @@ def create_app() -> Flask:
     app.register_blueprint(auth_routes)
     app.register_blueprint(public_routes)
     app.register_blueprint(user_routes)
-    
+
     return app

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -1,60 +1,62 @@
 from flask import Blueprint, render_template, current_app, session, request, redirect
-from ..spotify import SpotifyApi
+from ..spotify import SpotifyAuth
 from .controlador import AuthCtrl
 from ..decorators import no_login_required
 
 auth_routes = Blueprint('auth', __name__)
+
 
 @auth_routes.get("/login")
 @no_login_required
 def html_login():
     return render_template("login.html")
 
+
 @auth_routes.get("/login-spotify")
 @no_login_required
 def login():
-    spotify_client:SpotifyApi = current_app.config.get("spotify_client")
-    res = {"url": spotify_client.get_url_oauth()}
-    print(res)
-    return res
+    auth: SpotifyAuth = current_app.config["spotify_auth"]
+    return {"url": auth.get_url_oauth()}
+
 
 @auth_routes.post("/logining")
 @no_login_required
 def callback():
-    spotify_client:SpotifyApi = current_app.config.get("spotify_client")
-    spotify_client.redirect_uri = (request.host_url + "login").replace("http://", "https://")
+    auth: SpotifyAuth = current_app.config["spotify_auth"]
+    redirect_uri = (request.host_url + "login").replace("http://", "https://")
 
-    data:dict = request.json
+    data: dict = request.json
     code = data.get("code")
-    codeVerifier = data.get("codeVerifier")
+    code_verifier = data.get("codeVerifier")
 
-    data_token = spotify_client.obtener_token(code, codeVerifier)
+    data_token = auth.obtener_token(code, code_verifier, redirect_uri_override=redirect_uri)
     if not data_token:
         return {"status": False}
-    
+
     token = data_token["access_token"]
     refresh_token = data_token["refresh_token"]
-    
-    spotify_client.refresh_token = refresh_token
-    spotify_client.init_sp_client(token)
 
-    current_user = spotify_client.info_usuario()
-    username, id, uri = current_user["display_name"], current_user["id"], current_user["uri"]
-    img = ""
-    
-    if images:=current_user["images"]:
-        img = images[0]["url"]
+    from ..spotify import SpotifyClient
+    client = SpotifyClient(token, refresh_token, auth)
+    current_user = client.info_usuario()
 
-    AuthCtrl.login(username, id, uri, img)
+    username = current_user["display_name"]
+    user_id = current_user["id"]
+    uri = current_user["uri"]
+    img = current_user["images"][0]["url"] if current_user.get("images") else ""
+
+    AuthCtrl.login(username, user_id, uri, img)
 
     session["user"] = {
         "username": username,
-        "id": id,
+        "id": user_id,
         "uri": uri,
         "img": img,
-        "token": token
+        "token": token,
+        "refresh_token": refresh_token,
     }
     return {"status": True}
+
 
 @auth_routes.get("/logout")
 def logout():

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -25,9 +25,11 @@ def callback():
     auth: SpotifyAuth = current_app.config["spotify_auth"]
     redirect_uri = (request.host_url + "login").replace("http://", "https://")
 
-    data: dict = request.json
+    data = request.get_json(silent=True) or {}
     code = data.get("code")
     code_verifier = data.get("codeVerifier")
+    if not code or not code_verifier:
+        return {"status": False, "error": "missing code or codeVerifier"}, 400
 
     data_token = auth.obtener_token(code, code_verifier, redirect_uri_override=redirect_uri)
     if not data_token:
@@ -60,5 +62,5 @@ def callback():
 
 @auth_routes.get("/logout")
 def logout():
-    del session["user"]
+    session.pop("user", None)
     return redirect("/")

--- a/app/public/routes.py
+++ b/app/public/routes.py
@@ -31,7 +31,8 @@ def escuchar(id):
     uri = cancion["uri"]
     title = cancion.get("name")
     duration = cancion.get("duration_ms")
-    url_img = cancion.get("album", {}).get("images", [{}, {}])[1].get("url", "")
+    images = cancion.get("album", {}).get("images", []) or []
+    url_img = (images[1] if len(images) > 1 else images[0] if images else {}).get("url", "")
     artistas = map(lambda a: a["name"], cancion.get("artists", [{}]))
 
     return render_template('reproductor.html', id=id, uri=uri, title=title, artistas=list(artistas), duration=duration, url_img=url_img)
@@ -43,10 +44,12 @@ def recomendar():
     if not client:
         return "No autenticado", 401
 
-    data = request.json
+    data = request.get_json(silent=True) or {}
     historial = data.get("historial")
     nombre_cancion = data.get("nombre_cancion")
     artista = data.get("artista")
+    if not nombre_cancion or not artista:
+        return "Faltan campos requeridos", 400
 
     df_user = recomendacion.crear_df_user(historial)
     res_recomendacion = recomendacion.get_best_recommendations(nombre_cancion, artista, recomendacion.matriz_similaridad, df_user)

--- a/app/public/routes.py
+++ b/app/public/routes.py
@@ -1,79 +1,90 @@
-from flask import Blueprint, render_template, current_app, request
-from ..spotify import SpotifyApi
-
+from flask import Blueprint, render_template, request
+from ..spotify import get_spotify_client
 from ..algoritmo import recomendacion
-
-from pprint import pprint
 
 public_routes = Blueprint('public', __name__)
 
+
 @public_routes.get("/")
 def index():
-    spotify_client:SpotifyApi = current_app.config.get("spotify_client")
-    artistas = spotify_client.obtener_artistas() or []
-    tracks = spotify_client.user_top_tracks(8) or []
+    client = get_spotify_client()
+    artistas = client.obtener_artistas() if client else []
+    tracks = client.user_top_tracks(8) if client else []
     return render_template('index.html', artistas=artistas, tracks=tracks)
+
 
 @public_routes.get("/top")
 def get_top_tracks():
-    spotify_client:SpotifyApi = current_app.config.get("spotify_client")
-    return spotify_client.user_top_tracks(5) or []
+    client = get_spotify_client()
+    if not client:
+        return [], 401
+    return client.user_top_tracks(5) or []
+
 
 @public_routes.get("/escuchar/<string:id>")
 def escuchar(id):
-    spotify_client:SpotifyApi = current_app.config.get("spotify_client")
-    cancion:dict = spotify_client.obtener_cancion(id)
-    
+    client = get_spotify_client()
+    if not client:
+        return "No autenticado", 401
+    cancion: dict = client.obtener_cancion(id)
+
     uri = cancion["uri"]
     title = cancion.get("name")
     duration = cancion.get("duration_ms")
     url_img = cancion.get("album", {}).get("images", [{}, {}])[1].get("url", "")
-    artistas =map(lambda a: a["name"], cancion.get("artists", [{}]))
-    
+    artistas = map(lambda a: a["name"], cancion.get("artists", [{}]))
+
     return render_template('reproductor.html', id=id, uri=uri, title=title, artistas=list(artistas), duration=duration, url_img=url_img)
+
 
 @public_routes.post("/recomendar")
 def recomendar():
+    client = get_spotify_client()
+    if not client:
+        return "No autenticado", 401
+
     data = request.json
     historial = data.get("historial")
     nombre_cancion = data.get("nombre_cancion")
     artista = data.get("artista")
 
-    # with open("info.json", "w") as f:
-        # f.write(str(historial))
-
     df_user = recomendacion.crear_df_user(historial)
-
     res_recomendacion = recomendacion.get_best_recommendations(nombre_cancion, artista, recomendacion.matriz_similaridad, df_user)
-    
-    
-    spotify_client:SpotifyApi = current_app.config.get("spotify_client")
 
     URIs = res_recomendacion[:, -1]
-    canciones = spotify_client.obtener_info_canciones(URIs)
-    
+    canciones = client.obtener_info_canciones(URIs)
+
     return [
-            {
-                "id": item["id"], 
-                "title": item['name'],
-                "artist": item['artists'][0]['name'],
-                "uri": item["uri"],
-                "img": item["album"]["images"][-1]["url"],
-                "duration": item["duration_ms"]
-            } 
-            for item in canciones["tracks"]
+        {
+            "id": item["id"],
+            "title": item['name'],
+            "artist": item['artists'][0]['name'],
+            "uri": item["uri"],
+            "img": item["album"]["images"][-1]["url"],
+            "duration": item["duration_ms"],
+        }
+        for item in canciones["tracks"]
     ]
+
 
 @public_routes.get("/buscar")
 def buscar():
     args = request.args
     query = args.get("q")
 
-    spotify_client:SpotifyApi = current_app.config.get("spotify_client")
-    
-    if not query:
+    client = get_spotify_client()
+    if not query or not client:
         return render_template('busqueda.html', canciones=[])
-    
-    res = spotify_client.buscar_cancion(query)
-    canciones = ({"id": track["id"], "title": track["name"], "img": track["album"]["images"][0]["url"], "duration": track["duration_ms"], "artist": [artist["name"] for artist in track["artists"]] } for track in res["tracks"]["items"])
+
+    res = client.buscar_cancion(query)
+    canciones = (
+        {
+            "id": track["id"],
+            "title": track["name"],
+            "img": track["album"]["images"][0]["url"],
+            "duration": track["duration_ms"],
+            "artist": [artist["name"] for artist in track["artists"]],
+        }
+        for track in res["tracks"]["items"]
+    )
     return render_template('busqueda.html', canciones=canciones)

--- a/app/spotify/__init__.py
+++ b/app/spotify/__init__.py
@@ -1,1 +1,2 @@
-from .spotify import SpotifyApi
+from .spotify import SpotifyAuth, SpotifyClient
+from .utils import get_spotify_client

--- a/app/spotify/spotify.py
+++ b/app/spotify/spotify.py
@@ -4,6 +4,10 @@ from functools import wraps
 from typing import Optional
 
 
+class TokenExpiredError(Exception):
+    """Señal interna para que el decorador renueve el token y reintente."""
+
+
 def renew_token_if_needed(func):
     @wraps(func)
     def wrapper(self, *args, **kwargs):
@@ -13,8 +17,10 @@ def renew_token_if_needed(func):
             if e.http_status == 401:
                 self.renovar_token()
                 return func(self, *args, **kwargs)
-            else:
-                raise
+            raise
+        except TokenExpiredError:
+            self.renovar_token()
+            return func(self, *args, **kwargs)
     return wrapper
 
 
@@ -76,10 +82,23 @@ class SpotifyClient:
 
     def renovar_token(self):
         result = self._auth.refresh_access_token(self.refresh_token)
-        if result:
-            self.token = result["access_token"]
-            self.refresh_token = result.get("refresh_token", self.refresh_token)
-            self._client = Spotify(auth=self.token)
+        if not result:
+            return
+        self.token = result["access_token"]
+        self.refresh_token = result.get("refresh_token", self.refresh_token)
+        self._client = Spotify(auth=self.token)
+
+        # Propagar a la sesión para que el próximo request arranque con el token nuevo.
+        try:
+            from flask import session, has_request_context
+            if has_request_context():
+                user = session.get("user")
+                if isinstance(user, dict):
+                    user["token"] = self.token
+                    user["refresh_token"] = self.refresh_token
+                    session["user"] = user
+        except RuntimeError:
+            pass
 
     @renew_token_if_needed
     def info_usuario(self):
@@ -98,7 +117,7 @@ class SpotifyClient:
                 "title": item['name'],
                 "artist_name": item['artists'][0]['name'],
                 "uri": item["uri"],
-                "img": item["album"]["images"][1]["url"],
+                "img": _pick_image_url(item.get("album", {}).get("images", [])),
             }
             for item in top_tracks['items']
         ]
@@ -118,21 +137,29 @@ class SpotifyClient:
             "https://api.spotify.com/v1/recommendations?limit=8&seed_genres=anime,pop,raggeton,j-pop",
             headers=headers,
         )
+        if res.status_code == 401:
+            raise TokenExpiredError()
         if res.status_code != 200:
             return []
 
         info_artistas = []
-        for data in res.json()["tracks"]:
-            images = data.get("album", {}).get("images", [{}])
-            img = list(filter(lambda img: img["height"] >= 300, images))[0]
-            data_artista = data["artists"]
-            info_artistas += [
-                {
-                    "id": artista["id"],
-                    "name": artista["name"],
-                    "link": artista["external_urls"]["spotify"],
-                    "img": img.get("url", ""),
-                }
-                for artista in data_artista
-            ]
+        for data in res.json().get("tracks", []):
+            img_url = _pick_image_url(data.get("album", {}).get("images", []), min_height=300)
+            for artista in data.get("artists", []):
+                info_artistas.append({
+                    "id": artista.get("id"),
+                    "name": artista.get("name"),
+                    "link": artista.get("external_urls", {}).get("spotify", ""),
+                    "img": img_url,
+                })
         return info_artistas
+
+
+def _pick_image_url(images: list, min_height: int = 0) -> str:
+    """Devuelve la URL de una imagen segura; prefiere una con height >= min_height."""
+    if not images:
+        return ""
+    for img in images:
+        if img.get("height", 0) >= min_height:
+            return img.get("url", "")
+    return images[0].get("url", "")

--- a/app/spotify/spotify.py
+++ b/app/spotify/spotify.py
@@ -1,8 +1,8 @@
 import requests
-from spotipy import Spotify, util, SpotifyException
-from functools import wraps 
+from spotipy import Spotify, SpotifyException
+from functools import wraps
 from typing import Optional
-from pprint import pprint
+
 
 def renew_token_if_needed(func):
     @wraps(func)
@@ -10,159 +10,129 @@ def renew_token_if_needed(func):
         try:
             return func(self, *args, **kwargs)
         except SpotifyException as e:
-            print(e.http_status)
-            if e.http_status == 401:  # Unauthorized
-                self.obtener_nuevo_token()
+            if e.http_status == 401:
+                self.renovar_token()
                 return func(self, *args, **kwargs)
             else:
                 raise
     return wrapper
 
-class SpotifyApi:
+
+class SpotifyAuth:
     """
-    Una clase para interactuar con la API de Spotify.
-    
-    Atributos:
-        TOKEN_ENDPOINT (str): El endpoint para obtener tokens de Spotify.
-        __client_id (str): El ID de cliente para la aplicación de Spotify.
-        __client_secret (str): El secreto de cliente para la aplicación de Spotify.
-        scope (str): El alcance de la solicitud de acceso.
-        __username (str): El nombre de usuario de Spotify.
-        redirect_uri (str): La URI de redirección para la aplicación de Spotify.
-        spotify_client (Spotify): La instancia del cliente de Spotify.
-        token (str): El token de acceso.
-        refresh_token (str): El token de actualización.
-    
-    Métodos:
-        get_url_oauth(): Genera la URL de OAuth para la autorización del usuario.
-        obtener_nuevo_token(): Obtiene un nuevo token de acceso usando el token de actualización.
-        req_obtener_nuevo_token(refresh_token): Solicita un nuevo token de acceso usando el token de actualización.
-        obtener_token(code, code_verifier): Obtiene un token de acceso usando el código de autorización.
-        init_sp_client(token): Inicializa el cliente de Spotify con el token dado.
-        info_usuario(): Obtiene la información del usuario actual.
-        buscar_cancion(nombre): Busca una canción por su nombre.
-        user_top_tracks(top): Obtiene las canciones principales del usuario actual.
-        obtener_cancion(id): Obtiene información sobre una canción específica por su ID.
-        obtener_info_canciones(q): Obtiene información sobre múltiples canciones.
-        obtener_artistas(): Obtiene artistas recomendados basados en géneros semilla.
+    Maneja la configuración OAuth de Spotify (client_id, secret, scopes).
+    No guarda tokens — esos viven en la sesión de cada usuario.
     """
     TOKEN_ENDPOINT = "https://accounts.spotify.com/api/token"
 
-    def __init__(self, client_id:str, secret_client:str, username:str, scope:str, redirect_uri:str) -> None:
+    def __init__(self, client_id: str, client_secret: str, scope: str, redirect_uri: str) -> None:
         self.__client_id = client_id
-        self.__client_secret = secret_client
+        self.__client_secret = client_secret
         self.scope = scope
-        self.__username = username
         self.redirect_uri = redirect_uri
-        
-        self.spotify_client:Spotify = None
-        self.token:str = None
-        self.refresh_token:str = None
 
-        print(self.get_url_oauth()) 
-        token = util.prompt_for_user_token(self.__username, self.scope, self.__client_id, self.__client_secret, self.redirect_uri)
-        self.init_sp_client(token)
+    @property
+    def client_id(self):
+        return self.__client_id
 
     def get_url_oauth(self):
         return f"https://accounts.spotify.com/authorize?client_id={self.__client_id}&scope={self.scope}&response_type=code"
-    
-    def obtener_nuevo_token(self):
-        if tk:=self.refresh_token:
-            res = self.req_obtener_nuevo_token(tk)
-            if res:
-                self.refresh_token = res["refresh_token"]
-                self.init_sp_client(res["access_token"])
-        else:
-            token = util.prompt_for_user_token(self.__username, self.scope, self.__client_id, self.__client_secret, self.redirect_uri)
-            self.init_sp_client(token)
-    
-    def req_obtener_nuevo_token(self, refresh_token) -> Optional[dict]:
-        headers = {
-            "Content-Type": "application/x-www-form-urlencoded"
-        }
 
-        data = {
-            "client_id": self.__client_id,
-            "grant_type": "refresh_code",
-            "refresh_token": refresh_token
-        }
-        res = requests.post(SpotifyApi.TOKEN_ENDPOINT, data=data, headers=headers)
-        return res.json() if res.status_code == 200 else None
-
-    def obtener_token(self, code, code_verifier):
-        headers = {
-            "Content-Type": "application/x-www-form-urlencoded"
-        }
-        print("req redirect_uri", self.redirect_uri)
+    def obtener_token(self, code, code_verifier, redirect_uri_override=None):
+        headers = {"Content-Type": "application/x-www-form-urlencoded"}
         data = {
             "client_id": self.__client_id,
             "grant_type": "authorization_code",
             "code": code,
-            "redirect_uri": self.redirect_uri,
-            "code_verifier": code_verifier
+            "redirect_uri": redirect_uri_override or self.redirect_uri,
+            "code_verifier": code_verifier,
         }
+        res = requests.post(self.TOKEN_ENDPOINT, data=data, headers=headers)
+        if res.status_code != 200:
+            return None
+        return res.json()
 
-        res = requests.post(SpotifyApi.TOKEN_ENDPOINT, data=data, headers=headers)
-        pprint(res.json())
-        if res.status_code!=200: return None
-        data = res.json()
-        return data
+    def refresh_access_token(self, refresh_token: str) -> Optional[dict]:
+        headers = {"Content-Type": "application/x-www-form-urlencoded"}
+        data = {
+            "client_id": self.__client_id,
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+        }
+        res = requests.post(self.TOKEN_ENDPOINT, data=data, headers=headers)
+        return res.json() if res.status_code == 200 else None
 
-    def init_sp_client(self, token):
+
+class SpotifyClient:
+    """
+    Cliente Spotify por usuario. Se crea con el token de la sesión.
+    """
+
+    def __init__(self, token: str, refresh_token: str, auth: SpotifyAuth) -> None:
         self.token = token
-        self.spotify_client = Spotify(auth=token)
+        self.refresh_token = refresh_token
+        self._auth = auth
+        self._client = Spotify(auth=token)
+
+    def renovar_token(self):
+        result = self._auth.refresh_access_token(self.refresh_token)
+        if result:
+            self.token = result["access_token"]
+            self.refresh_token = result.get("refresh_token", self.refresh_token)
+            self._client = Spotify(auth=self.token)
 
     @renew_token_if_needed
     def info_usuario(self):
-        return self.spotify_client.current_user()
-    
+        return self._client.current_user()
+
     @renew_token_if_needed
     def buscar_cancion(self, nombre):
-        return self.spotify_client.search(nombre, limit=10)
+        return self._client.search(nombre, limit=10)
 
     @renew_token_if_needed
     def user_top_tracks(self, top):
-        top_tracks = self.spotify_client.current_user_top_tracks(time_range='short_term', limit=top)
+        top_tracks = self._client.current_user_top_tracks(time_range='short_term', limit=top)
         return [
             {
-                "id": item["id"], 
+                "id": item["id"],
                 "title": item['name'],
                 "artist_name": item['artists'][0]['name'],
                 "uri": item["uri"],
                 "img": item["album"]["images"][1]["url"],
-            } 
+            }
             for item in top_tracks['items']
         ]
-    
-    @renew_token_if_needed
-    def obtener_cancion(self, id):
-        return self.spotify_client.track(id)
 
     @renew_token_if_needed
-    def obtener_info_canciones(self, q:list):
-        return self.spotify_client.tracks(q)
+    def obtener_cancion(self, id):
+        return self._client.track(id)
+
+    @renew_token_if_needed
+    def obtener_info_canciones(self, q: list):
+        return self._client.tracks(q)
 
     @renew_token_if_needed
     def obtener_artistas(self):
-        headers = {
-            "Authorization": f"Bearer {self.token}"
-        }
-
-        res = requests.get(f"https://api.spotify.com/v1/recommendations?limit=8&seed_genres=anime,pop,raggeton,j-pop", headers=headers)
-        # &seed_tracks=0c6xIDDpzE81m2q797ordA
-
-        if res.status_code == 200:
-            artistas = res.json()
-            info_artistas = []
-
-            for data in artistas["tracks"]:
-                images = data.get("album",{}).get("images", [{}])
-                img = list(filter(lambda img: img["height"] >= 300, images))[0]
-
-                data_artista = data["artists"]
-                info_artistas+= [{"id":artista["id"], "name": artista["name"], "link":artista["external_urls"]["spotify"], "img":img.get("url", "")} for artista in data_artista]
-
-            return info_artistas
-        else:
-            print("Error al obtener los artistas:", res.text, res.status_code)
+        headers = {"Authorization": f"Bearer {self.token}"}
+        res = requests.get(
+            "https://api.spotify.com/v1/recommendations?limit=8&seed_genres=anime,pop,raggeton,j-pop",
+            headers=headers,
+        )
+        if res.status_code != 200:
             return []
+
+        info_artistas = []
+        for data in res.json()["tracks"]:
+            images = data.get("album", {}).get("images", [{}])
+            img = list(filter(lambda img: img["height"] >= 300, images))[0]
+            data_artista = data["artists"]
+            info_artistas += [
+                {
+                    "id": artista["id"],
+                    "name": artista["name"],
+                    "link": artista["external_urls"]["spotify"],
+                    "img": img.get("url", ""),
+                }
+                for artista in data_artista
+            ]
+        return info_artistas

--- a/app/spotify/utils.py
+++ b/app/spotify/utils.py
@@ -1,0 +1,15 @@
+from flask import session, current_app
+from .spotify import SpotifyClient, SpotifyAuth
+
+
+def get_spotify_client() -> SpotifyClient | None:
+    """Crea un SpotifyClient con el token de la sesión del usuario actual."""
+    user = session.get("user")
+    if not user or not user.get("token"):
+        return None
+    auth: SpotifyAuth = current_app.config["spotify_auth"]
+    return SpotifyClient(
+        token=user["token"],
+        refresh_token=user.get("refresh_token", ""),
+        auth=auth,
+    )


### PR DESCRIPTION
## Summary
- Split `SpotifyApi` (single global instance) into `SpotifyAuth` (app-level OAuth config) + `SpotifyClient` (per-request from session token)
- Tokens (`access_token`, `refresh_token`) now stored in Flask session per user
- `get_spotify_client()` helper creates a `SpotifyClient` from the current user's session
- Concurrent users no longer overwrite each other's Spotify tokens

## Changes
- `app/spotify/spotify.py` — `SpotifyApi` → `SpotifyAuth` + `SpotifyClient`
- `app/spotify/utils.py` — new `get_spotify_client()` helper
- `app/app.py` — stores `SpotifyAuth` instead of `SpotifyApi`, removed `SPOTIFY_USERNAME` dependency
- `app/auth/routes.py` — uses `SpotifyAuth` for OAuth, saves `refresh_token` to session
- `app/public/routes.py` — uses `get_spotify_client()` per request

## Test plan
- [ ] Login with Spotify still works
- [ ] Session persists token across requests (browse, search, play)
- [ ] Token refresh works on 401
- [ ] Two different users can be logged in simultaneously (different browsers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Switch Spotify integration to use app-level auth plus per-session clients to support multiple concurrent users without token conflicts.

New Features:
- Introduce SpotifyAuth to hold OAuth configuration and handle token and refresh workflows.
- Introduce SpotifyClient as a per-user Spotify client built from session tokens.
- Add get_spotify_client() helper to construct a SpotifyClient from the current Flask session.

Bug Fixes:
- Prevent concurrent users from overwriting each other’s Spotify tokens by moving tokens into per-user session storage.
- Ensure public and recommendation endpoints require an authenticated Spotify session and return 401 when missing.

Enhancements:
- Refactor public routes to use per-request SpotifyClient instances instead of a global client.
- Simplify auth callback flow to derive user profile via a temporary SpotifyClient and persist both access and refresh tokens in the session.
- Remove dependency on SPOTIFY_USERNAME and global SpotifyApi initialization during app startup.